### PR TITLE
Make integration tests recursive

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -118,7 +118,7 @@ test-unit-coverage:
 
 # Run the integration tests using mocha
 test-integration:
-	@if [ -d test/integration ]; then mocha test/integration --timeout $(INTEGRATION_TIMEOUT) --slow $(INTEGRATION_SLOW) $(INTEGRATION_FLAGS) && $(TASK_DONE); fi
+	@if [ -d test/integration ]; then mocha test/integration --recursive --timeout $(INTEGRATION_TIMEOUT) --slow $(INTEGRATION_SLOW) $(INTEGRATION_FLAGS) && $(TASK_DONE); fi
 
 
 # Service running tasks


### PR DESCRIPTION
This probably constitutes a breaking change. Currently services using
this Makefile will not run all of the integration tests because the
recursive flag is missing. I should have noticed this during testing.

It's safe to always add the flag for our services as they all have a
non-flat directory structure for the tests.