### PR TITLE
Simplify the boilerplate

### DIFF
--- a/boilerplate.mk
+++ b/boilerplate.mk
@@ -3,7 +3,6 @@
 # This section of the Makefile should not be modified, it includes
 # commands from the Origami service Makefile.
 # https://github.com/Financial-Times/origami-service-makefile
-node_modules/%/index.mk: package.json ; npm install $* ; touch $@
--include node_modules/@financial-times/origami-service-makefile/index.mk
+include node_modules/@financial-times/origami-service-makefile/index.mk
 # [edit below this line]
 # ------------------------


### PR DESCRIPTION
You now need to run an npm install before you can use the makefile