### PR TITLE
Vault env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Table Of Contents
 Usage
 -----
 
+The Origami Service Makefile requires [Node.js] 6.x and [npm].
+
 Origami Service Makefile provides a set of common tools that are required for building and running Origami services. To use the Makefile, copy the [`boilerplate.mk`](boilerplate.mk) file to the root of your repo and name it `Makefile`:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You should now be able to run the following commands:
 
 ```
 make install       # Install application dependencies
-make .env          # Update the .env file with enviroment variables from Vault
+make .env          # Update the .env file with environment variables from Vault
 make verify        # Verify code using static analysis
 make test          # Run unit and integration tests
 make run           # Run the application as if in production

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You should now be able to run the following commands:
 
 ```
 make install       # Install application dependencies
+make .env          # Update the .env file with enviroment variables from Vault
 make verify        # Verify code using static analysis
 make test          # Run unit and integration tests
 make run           # Run the application as if in production

--- a/index.mk
+++ b/index.mk
@@ -46,6 +46,7 @@ ci: verify test whitesource
 	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
 	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault auth --method github."; exit 1; fi
 	@if [[ -z "$(shell grep .env .gitignore)" ]]; then echo "Error: .gitignore must include .env"; exit 1; fi
+	@if [[ -z "$(shell grep .env .npmignore)" ]]; then echo "Error: .npmignore must include .env"; exit 1; fi
 	@SERVICE_SYSTEM_CODE=$(SERVICE_SYSTEM_CODE) REGION=$(REGION) node $(PATH_TO_SERVICE_MAKEFILE)lib/vault.js
 	@$(TASK_DONE)
 

--- a/index.mk
+++ b/index.mk
@@ -10,7 +10,6 @@
 
 # Import environment variables if an .env file is present
 ifneq ("$(wildcard .env)","")
-sinclude .env
 export $(shell [ -f .env ] && sed 's/=.*//' .env)
 $(info Note: importing environment variables from .env file)
 endif

--- a/index.mk
+++ b/index.mk
@@ -42,7 +42,7 @@ ci: verify test whitesource
 	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
 	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault auth --method github."; exit 1; fi
 	@if [[ -z "$(shell grep .env .gitignore)" ]]; then echo "Error: .gitignore must include .env"; exit 1; fi
-	@SERVICE_SYSTEM_CODE=$(SERVICE_SYSTEM_CODE) node vault.js
+	@SERVICE_SYSTEM_CODE=$(SERVICE_SYSTEM_CODE) REGION=$(REGION) node vault.js
 	@$(TASK_DONE)
 
 # Clean the Git repository

--- a/index.mk
+++ b/index.mk
@@ -36,6 +36,15 @@ ci: verify test whitesource
 # Install tasks
 # -------------
 
+# Update the .env file with secrets from Vault (https://github.com/Financial-Times/vault/wiki/)
+.PHONY: .env
+.env:
+	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
+	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault auth --method github."; exit 1; fi
+	@if [[ -z "$(shell grep .env .gitignore)" ]]; then echo "Error: .gitignore must include .env"; exit 1; fi
+	@SERVICE_SYSTEM_CODE=$(SERVICE_SYSTEM_CODE) node vault.js
+	@$(TASK_DONE)
+
 # Clean the Git repository
 clean:
 	@git clean -fxd

--- a/index.mk
+++ b/index.mk
@@ -2,7 +2,7 @@
 # Meta tasks
 # ----------
 
-.PHONY: test
+.PHONY: test .env
 
 
 # Configuration
@@ -42,7 +42,6 @@ ci: verify test whitesource
 # -------------
 
 # Update the .env file with secrets from Vault (https://github.com/Financial-Times/vault/wiki/)
-.PHONY: .env
 .env:
 	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
 	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault auth --method github."; exit 1; fi

--- a/index.mk
+++ b/index.mk
@@ -46,7 +46,7 @@ ci: verify test whitesource
 	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
 	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault auth --method github."; exit 1; fi
 	@if [[ -z "$(shell grep .env .gitignore)" ]]; then echo "Error: .gitignore must include .env"; exit 1; fi
-	@if [[ -z "$(shell grep .env .npmignore)" ]]; then echo "Error: .npmignore must include .env"; exit 1; fi
+	@if [[ "$(shell grep .env .npmignore --silent --no-messages; echo $$?)" -eq 1 ]]; then echo "Error: .npmignore must include .env"; exit 1; fi
 	@SERVICE_SYSTEM_CODE=$(SERVICE_SYSTEM_CODE) REGION=$(REGION) node $(PATH_TO_SERVICE_MAKEFILE)lib/vault.js
 	@$(TASK_DONE)
 

--- a/index.mk
+++ b/index.mk
@@ -18,9 +18,7 @@ endif
 NPM_BIN = ./node_modules/.bin
 export PATH := $(PATH):$(NPM_BIN)
 
-ifeq ("$(wildcard node_modules/@financial-times/origami-service-makefile/index.mk)","")
-PATH_TO_SERVICE_MAKEFILE :=
-else
+ifneq ("$(wildcard node_modules/@financial-times/origami-service-makefile/index.mk)","")
 PATH_TO_SERVICE_MAKEFILE := node_modules/@financial-times/origami-service-makefile/
 endif
 

--- a/index.mk
+++ b/index.mk
@@ -19,6 +19,12 @@ endif
 NPM_BIN = ./node_modules/.bin
 export PATH := $(PATH):$(NPM_BIN)
 
+ifeq ("$(wildcard node_modules/@financial-times/origami-service-makefile/index.mk)","")
+PATH_TO_SERVICE_MAKEFILE :=
+else
+PATH_TO_SERVICE_MAKEFILE := node_modules/@financial-times/origami-service-makefile/
+endif
+
 
 # Output helpers
 # --------------
@@ -42,7 +48,7 @@ ci: verify test whitesource
 	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
 	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault auth --method github."; exit 1; fi
 	@if [[ -z "$(shell grep .env .gitignore)" ]]; then echo "Error: .gitignore must include .env"; exit 1; fi
-	@SERVICE_SYSTEM_CODE=$(SERVICE_SYSTEM_CODE) REGION=$(REGION) node vault.js
+	@SERVICE_SYSTEM_CODE=$(SERVICE_SYSTEM_CODE) REGION=$(REGION) node $(PATH_TO_SERVICE_MAKEFILE)lib/vault.js
 	@$(TASK_DONE)
 
 # Clean the Git repository

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -29,10 +29,17 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     }
 
     // Get secrets object.
-    const existingSecrets = fs.readFileSync(envFile).toString().trim().split('\n').reduce((secretsObject, secret) => {
-        const secretArr = (secret.includes('=') ? secret.split('=') : null);
-        if (secretArr) {
-            secretsObject[secretArr[0]] = secretArr[1];
+    const existingComments = {};
+    const existingSecrets = fs.readFileSync(envFile).toString().trim().split('\n').reduce((secretsObject, line, index) => {
+        if (line.trim().indexOf('#') == 0) {
+            // Line is a comment.
+            existingComments[index] = line;
+        } else {
+            // Line is a secret (enviroment variable).
+            const secretArr = (line.includes('=') ? line.split('=') : null);
+            if (secretArr) {
+                secretsObject[secretArr[0]] = secretArr[1];
+            }
         }
         return secretsObject;
     }, {});
@@ -42,13 +49,17 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     // Create string of secrets for .env.
     const keys = Object.keys(secrets);
     let envContent = '';
-    for (index = keys.length - 1; index >= 0; index--) {
-        const key = keys[keys.length - index - 1];
+    for (index = 0; index <= keys.length - 1; index++) {
+        const comment = existingComments[index];
+        if (comment) {
+            envContent += `${comment}\n`;
+        }
+        const key = keys[index];
         envContent += `${key}=${secrets[key]}\n`;
     }
 
     // Write .env secrets.
-    fs.write(envFile, envContent, (err) => {
+    fs.writeFileSync(envFile, envContent, (err) => {
         if (err) {
             throw err;
         }

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -1,0 +1,56 @@
+const { exec } = require('child_process');
+const fs = require('fs');
+
+const service = process.env.SERVICE_SYSTEM_CODE;
+let region = (process.env.REGION || 'LOCAL').toLowerCase();
+const vaultPath = `secret/teams/origami/${service}/${region}`;
+const envFile = '.env';
+
+if (!service) {
+    console.warn(
+        'Could not load enviroment variables from Vault. Service name is undefined.',
+        'Set the enviroment variable "SERVICE_SYSTEM_CODE" in your Makefile.'
+    );
+    process.exit(1);
+}
+
+// Update an existing .env file with enviroment variables from Vault.
+exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
+    const result = err ? null : JSON.parse(stdout);
+
+    // Handle errors.
+    if (err || !result.data) {
+        console.warn(
+            `Could not load enviroment variables from Vault (${vaultPath}).`,
+            (stdout ? `\nstdout: ${stdout}` : ''),
+            (stderr ? `\nstderr: ${stderr}` : '')
+        );
+        process.exit(1);
+    }
+
+    // Get secrets object.
+    var existingSecrets = fs.readFileSync(envFile).toString().trim().split('\n');
+    existingSecrets = existingSecrets.reduce((secretsObject, secret) => {
+        const secretArr = (secret.includes('=') ? secret.split('=') : null);
+        if (secretArr) {
+            secretsObject[secretArr[0]] = secretArr[1];
+        }
+        return secretsObject;
+    }, {});
+    const vaultSecrets = result.data;
+    const secrets = Object.assign(existingSecrets, vaultSecrets)
+
+    // Create string of secrets for .env.
+    const keys = Object.keys(secrets);
+    let envContent = '';
+    for (index = keys.length - 1; index >= 0; index--) {
+        const key = keys[keys.length - index - 1];
+        envContent += `${key}=${secrets[key]}\n`;
+    }
+
+    // Write .env secrets.
+    fs.writeFile(envFile, envContent, () => {
+        console.log(`Vault secrets for "${service}" have been written to .env`);
+        process.exit(1);
+    });
+});

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -27,21 +27,25 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
         );
     }
 
-    // Get secrets object.
-    const existingComments = {};
-    const existingSecrets = fs.readFileSync(envFile).toString().trim().split('\n').reduce((secretsObject, line, index) => {
-        if (line.startsWith('#')) {
-            // Line is a comment.
-            existingComments[index] = line;
-        } else {
-            // Line is a secret (environment variable).
-            const secretArr = (line.includes('=') ? line.split('=') : null);
-            if (secretArr) {
-                secretsObject[secretArr[0]] = secretArr[1];
+
+    // Get existings secrets and comments from the .env file.
+    let existingComments = {};
+    let existingSecrets = {};
+    if (fs.existsSync(envFile)) {
+        existingSecrets = fs.readFileSync(envFile).toString().trim().split('\n').reduce((secretsObject, line, index) => {
+            if (line.startsWith('#')) {
+                // Line is a comment.
+                existingComments[index] = line;
+            } else {
+                // Line is a secret (environment variable).
+                const secretArr = (line.includes('=') ? line.split('=') : null);
+                if (secretArr) {
+                    secretsObject[secretArr[0]] = secretArr[1];
+                }
             }
-        }
-        return secretsObject;
-    }, {});
+            return secretsObject;
+        }, {});
+    }
 
     // Get secrets from Vault.
     const vaultSecrets = result.data;
@@ -61,25 +65,32 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
 
     // Combine secrets and create string of secrets for .env.
     const secrets = Object.assign({}, existingSecrets, vaultSecrets)
-    const keys = Object.keys(secrets);
+    const secrentKeys = Object.keys(secrets);
     let envContent = '';
-    for (let index = 0; index <= keys.length - 1; index++) {
+    for (let index = 0; index <= secrentKeys.length - 1; index++) {
         const comment = existingComments[index];
         if (comment) {
             envContent += `${comment}\n`;
         }
-        const key = keys[index];
+        const key = secrentKeys[index];
         envContent += `${key}=${secrets[key]}\n`;
     }
 
     // Write .env secrets.
-    fs.writeFileSync(envFile, envContent);
-    console.log(`Vault secrets for "${service}" have been written to ${envFile}`);
+    if (secrentKeys.length > 0) {
+        fs.writeFileSync(envFile, envContent);
+        console.log(`Vault secrets for "${service}" have been written to ${envFile}.`);
+    } else {
+        console.log(`No secrets to write to ${envFile}.`);
+    }
 
     // Warn of variables which are not in Vault.
     const nonVaultSecretKeys = Object.keys(existingSecrets).filter((existingKey) => {
         return !vaultSecretKeys.includes(existingKey);
     });
-    console.log(`The following environment variables are custom and not stored in Vault:\n${nonVaultSecretKeys}.`);
+    if (nonVaultSecretKeys.length > 0) {
+        console.log(`The following environment variables are custom and not stored in Vault:\n${nonVaultSecretKeys}.`);
+    }
+
     process.exitCode = 0;
 });

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -8,20 +8,20 @@ const envFile = '.env';
 
 if (!service) {
     console.warn(
-        'Could not load enviroment variables from Vault. Service name is undefined.',
-        'Set the enviroment variable "SERVICE_SYSTEM_CODE" in your Makefile.'
+        'Could not load environment variables from Vault. Service name is undefined.',
+        'Set the environment variable "SERVICE_SYSTEM_CODE" in your Makefile.'
     );
     process.exit(1);
 }
 
-// Update an existing .env file with enviroment variables from Vault.
+// Update an existing .env file with environment variables from Vault.
 exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     const result = err ? null : JSON.parse(stdout);
 
     // Handle errors.
     if (err || !result.data) {
         console.warn(
-            `Could not load enviroment variables from Vault (${vaultPath}).`,
+            `Could not load environment variables from Vault (${vaultPath}).`,
             (stdout ? `\nstdout: ${stdout}` : ''),
             (stderr ? `\nstderr: ${stderr}` : '')
         );
@@ -35,7 +35,7 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
             // Line is a comment.
             existingComments[index] = line;
         } else {
-            // Line is a secret (enviroment variable).
+            // Line is a secret (environment variable).
             const secretArr = (line.includes('=') ? line.split('=') : null);
             if (secretArr) {
                 secretsObject[secretArr[0]] = secretArr[1];
@@ -66,6 +66,6 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     const nonVaultSecretKeys = Object.keys(existingSecrets).filter((existingKey) => {
         return !vaultSecretKeys.includes(existingKey);
     });
-    console.log(`The following enviroment variables are custom and not stored in Vault:\n${nonVaultSecretKeys}.`);
+    console.log(`The following environment variables are custom and not stored in Vault:\n${nonVaultSecretKeys}.`);
     process.exit(1);
 });

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -60,6 +60,12 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
 
     // Write .env secrets.
     fs.writeFileSync(envFile, envContent);
-    console.log(`Vault secrets for "${service}" have been written to .env`);
+    console.log(`Vault secrets for "${service}" have been written to ${envFile}`);
+    // Warn of variables which are not in Vault.
+    const vaultSecretKeys = Object.keys(vaultSecrets);
+    const nonVaultSecretKeys = Object.keys(existingSecrets).filter((existingKey) => {
+        return !vaultSecretKeys.includes(existingKey);
+    });
+    console.log(`The following enviroment variables are custom and not stored in Vault:\n${nonVaultSecretKeys}.`);
     process.exit(1);
 });

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -66,14 +66,18 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     // Combine secrets and create string of secrets for .env.
     const secrets = Object.assign({}, existingSecrets, vaultSecrets)
     const secrentKeys = Object.keys(secrets);
+    const envLineLength = secrentKeys.length + Object.keys(existingComments).length;
     let envContent = '';
-    for (let index = 0; index <= secrentKeys.length - 1; index++) {
+    let numberofComments = 0;
+    for (let index = 0; index <= envLineLength - 1; index++) {
         const comment = existingComments[index];
         if (comment) {
+            numberofComments++;
             envContent += `${comment}\n`;
+        } else {
+            const key = secrentKeys[index - numberofComments];
+            envContent += `${key}=${secrets[key]}\n`;
         }
-        const key = secrentKeys[index];
-        envContent += `${key}=${secrets[key]}\n`;
     }
 
     // Write .env secrets.

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -59,11 +59,7 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     }
 
     // Write .env secrets.
-    fs.writeFileSync(envFile, envContent, (err) => {
-        if (err) {
-            throw err;
-        }
-        console.log(`Vault secrets for "${service}" have been written to .env`);
-        process.exit(1);
-    });
+    fs.writeFileSync(envFile, envContent);
+    console.log(`Vault secrets for "${service}" have been written to .env`);
+    process.exit(1);
 });

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -69,5 +69,5 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
         return !vaultSecretKeys.includes(existingKey);
     });
     console.log(`The following environment variables are custom and not stored in Vault:\n${nonVaultSecretKeys}.`);
-    process.exit(1);
+    process.exit(0);
 });

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -33,7 +33,7 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     // Get secrets object.
     const existingComments = {};
     const existingSecrets = fs.readFileSync(envFile).toString().trim().split('\n').reduce((secretsObject, line, index) => {
-        if (line.trim().indexOf('#') == 0) {
+        if (line.startsWith('#')) {
             // Line is a comment.
             existingComments[index] = line;
         } else {

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -45,10 +45,26 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
         }
         return secretsObject;
     }, {});
-    const vaultSecrets = result.data;
-    const secrets = Object.assign(existingSecrets, vaultSecrets)
 
-    // Create string of secrets for .env.
+    // Get secrets from Vault.
+    const vaultSecrets = result.data;
+    const vaultSecretKeys = Object.keys(vaultSecrets);
+
+    // Check local secrets which will be replaced with Vault vaules for inline comments.
+    const replacedSecretKeys = Object.keys(existingSecrets).filter((existingKey) => {
+        return vaultSecretKeys.includes(existingKey);
+    });
+    replacedSecretKeys.forEach((replacedSecretKey) => {
+        const replacedSecret = existingSecrets[replacedSecretKey];
+        const inlineComments = /^\s*(?:"(?:.*?)"|'(?:.*?)'|(?:[^\s#]*))?\s*(#.*)/mg;
+        if (inlineComments.exec(replacedSecret)) {
+            console.log(`The "${replacedSecretKey}" enviroment variable has an inline comment. Please move this comment to its own line.`);
+            process.exit(1);
+        }
+    });
+
+    // Combine secrets and create string of secrets for .env.
+    const secrets = Object.assign({}, existingSecrets, vaultSecrets)
     const keys = Object.keys(secrets);
     let envContent = '';
     for (let index = 0; index <= keys.length - 1; index++) {
@@ -63,8 +79,8 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     // Write .env secrets.
     fs.writeFileSync(envFile, envContent);
     console.log(`Vault secrets for "${service}" have been written to ${envFile}`);
+
     // Warn of variables which are not in Vault.
-    const vaultSecretKeys = Object.keys(vaultSecrets);
     const nonVaultSecretKeys = Object.keys(existingSecrets).filter((existingKey) => {
         return !vaultSecretKeys.includes(existingKey);
     });

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const { exec } = require('child_process');
 const fs = require('fs');
 
@@ -49,7 +51,7 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     // Create string of secrets for .env.
     const keys = Object.keys(secrets);
     let envContent = '';
-    for (index = 0; index <= keys.length - 1; index++) {
+    for (let index = 0; index <= keys.length - 1; index++) {
         const comment = existingComments[index];
         if (comment) {
             envContent += `${comment}\n`;

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -29,8 +29,7 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     }
 
     // Get secrets object.
-    var existingSecrets = fs.readFileSync(envFile).toString().trim().split('\n');
-    existingSecrets = existingSecrets.reduce((secretsObject, secret) => {
+    const existingSecrets = fs.readFileSync(envFile).toString().trim().split('\n').reduce((secretsObject, secret) => {
         const secretArr = (secret.includes('=') ? secret.split('=') : null);
         if (secretArr) {
             secretsObject[secretArr[0]] = secretArr[1];
@@ -49,7 +48,10 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
     }
 
     // Write .env secrets.
-    fs.writeFile(envFile, envContent, () => {
+    fs.write(envFile, envContent, (err) => {
+        if (err) {
+            throw err;
+        }
         console.log(`Vault secrets for "${service}" have been written to .env`);
         process.exit(1);
     });

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -9,11 +9,8 @@ const vaultPath = `secret/teams/origami/${service}/${region}`;
 const envFile = '.env';
 
 if (!service) {
-    console.warn(
-        'Could not load environment variables from Vault. Service name is undefined.',
-        'Set the environment variable "SERVICE_SYSTEM_CODE" in your Makefile.'
-    );
-    process.exit(1);
+    throw new Error(`Could not load environment variables from Vault without a service code.
+    Set the environment variable "SERVICE_SYSTEM_CODE" in your Makefile.`);
 }
 
 // Update an existing .env file with environment variables from Vault.
@@ -22,12 +19,12 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
 
     // Handle errors.
     if (err || !result.data) {
-        console.warn(
-            `Could not load environment variables from Vault (${vaultPath}).`,
-            (stdout ? `\nstdout: ${stdout}` : ''),
-            (stderr ? `\nstderr: ${stderr}` : '')
+        throw new Error(`
+            Could not load environment variables from Vault (${vaultPath}).
+            ${stdout ? `\nstdout: ${stdout}` : ''}
+            ${stderr ? `\nstdout: ${stderr}` : ''}
+            `
         );
-        process.exit(1);
     }
 
     // Get secrets object.
@@ -58,8 +55,7 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
         const replacedSecret = existingSecrets[replacedSecretKey];
         const inlineComments = /^\s*(?:"(?:.*?)"|'(?:.*?)'|(?:[^\s#]*))?\s*(#.*)/mg;
         if (inlineComments.exec(replacedSecret)) {
-            console.log(`The "${replacedSecretKey}" enviroment variable has an inline comment. Please move this comment to its own line.`);
-            process.exit(1);
+            throw new Error(`The "${replacedSecretKey}" enviroment variable has an inline comment. Please move this comment to its own line.`);
         }
     });
 
@@ -85,5 +81,5 @@ exec(`vault read -format=json ${vaultPath}`, (err, stdout, stderr) => {
         return !vaultSecretKeys.includes(existingKey);
     });
     console.log(`The following environment variables are custom and not stored in Vault:\n${nonVaultSecretKeys}.`);
-    process.exit(0);
+    process.exitCode = 0;
 });

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -2,7 +2,7 @@ const { exec } = require('child_process');
 const fs = require('fs');
 
 const service = process.env.SERVICE_SYSTEM_CODE;
-let region = (process.env.REGION || 'LOCAL').toLowerCase();
+const region = (process.env.REGION || 'LOCAL').toLowerCase();
 const vaultPath = `secret/teams/origami/${service}/${region}`;
 const envFile = '.env';
 


### PR DESCRIPTION
Adds a `make .env` command to update a local `.env` file with environment variables from Vault. 

These can be accessed through the [web ui](https://vault-ui.in.ft.com/secrets/generic/secret/teams/origami/origami-registry-ui/local) or via the vault cli. See the [getting started guide](https://github.com/Financial-Times/vault/wiki/Getting-Started).

Vault secrets are stored in a directory structure. The structure I've gone for is `origami/${systemCode}/${region}/`. E.g. `origami/origami-registry-ui/local`.

**Suggested Next steps:**

Use Vault for all env storage/retrieval.
- Push all secrets to Vault (local and otherwise).
- Update services docs to call `make .env` after `make install` for local development.
- Update documentation to point to Vault rather than LastPass to retrieve production environment variables.
- Remove secrets from LastPass..?

That's a safe milestone with secrets manageable outside of LastPass and auto .env population to get up and running locally. We may then follow up by enabling qa/production environment variables to update automatically, perhaps using a [vault webhook](https://github.com/Financial-Times/vault/wiki/Webhooks) along the lines of [next-vault-sync](https://github.com/Financial-Times/next-vault-sync)
