### PR TITLE
Skip CMDB step as the api is decommissioned.

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -190,7 +190,7 @@ auto-version:
 
 # Update all CMDB endpoints
 cmdb-update:
-	@if [ -d operational-documentation ]; then make cmdb-checks cmdb-update-eu cmdb-update-us cmdb-update-runbook && $(TASK_DONE); fi
+	@if [ -d operational-documentation ]; then make cmdb-checks && echo "Skipping CMDB update. The CMDB API is decommissioned in favor of the new BIZ-OPS API. https://github.com/Financial-Times/origami-service-makefile/issues/20" && $(TASK_DONE); fi
 
 # Update the CMDB endpoint for the EU application
 cmdb-update-eu:


### PR DESCRIPTION
This unblocks the release of our services. 

I've created an issue to upgrade to use the new bizops api:
https://github.com/Financial-Times/origami-service-makefile/issues/20

I've retained the cmdb-check to ensure we continue to enforce the environment variables we expect. The cmdb tasks are also retained e.g. `cmdb-update-eu` but are not run by `cmdb-update`.