### PR TITLE
Remove esm from the tests

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -99,17 +99,17 @@ test: test-unit-coverage verify-coverage test-integration
 
 # Run the unit tests using mocha
 test-unit:
-	@if [ -d test/unit ]; then mocha -r esm "test/unit/**/*.test.js" --recursive && $(TASK_DONE); fi
+	@if [ -d test/unit ]; then mocha "test/unit/**/*.test.js" --recursive && $(TASK_DONE); fi
 
 # Run the unit tests using mocha and generating
 # a coverage report if nyc or istanbul are installed
 test-unit-coverage:
 	@if [ -d test/unit ]; then \
 		if [ -x $(NPM_BIN)/nyc ]; then \
-			nyc --reporter=text --reporter=html $(NPM_BIN)/_mocha  -r esm "test/unit/**/*.test.js" --recursive && $(TASK_DONE); \
+			nyc --reporter=text --reporter=html $(NPM_BIN)/_mocha "test/unit/**/*.test.js" --recursive && $(TASK_DONE); \
 		else \
 			if [ -x $(NPM_BIN)/istanbul ]; then \
-				istanbul cover $(NPM_BIN)/_mocha --  -r esm "test/unit/**/*.test.js" --recursive && $(TASK_DONE); \
+				istanbul cover $(NPM_BIN)/_mocha -- "test/unit/**/*.test.js" --recursive && $(TASK_DONE); \
 			else \
 				make test-unit; \
 			fi \
@@ -118,7 +118,7 @@ test-unit-coverage:
 
 # Run the integration tests using mocha
 test-integration:
-	@if [ -d test/integration ]; then mocha  -r esm "test/integration/**/*.test.js" --recursive --timeout $(INTEGRATION_TIMEOUT) --slow $(INTEGRATION_SLOW) $(INTEGRATION_FLAGS) && $(TASK_DONE); fi
+	@if [ -d test/integration ]; then mocha "test/integration/**/*.test.js" --recursive --timeout $(INTEGRATION_TIMEOUT) --slow $(INTEGRATION_SLOW) $(INTEGRATION_FLAGS) && $(TASK_DONE); fi
 
 
 # Service running tasks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,5 @@
 {
   "name": "@financial-times/origami-service-makefile",
   "version": "0.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "esm": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.18.tgz",
-      "integrity": "sha512-rkoylON9QyeKy33mZR8yYTdQeuqogI+G/h2TUf6/NIaW2Ivh4s2BXIMhi5aw1xDAsdWIJCnFQDu5GDMyoxRlgw=="
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,5 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/origami-service-makefile.git"
   },
-  "main": "index.mk",
-  "dependencies": {
-    "esm": "^3.0.18"
-  }
+  "main": "index.mk"
 }


### PR DESCRIPTION
This reverts commit d2e8adb221bc7ab4d0c31fcad8851fe6151a83d1. We were
having timeout and memory issues due to this when we updated mocha, nyc,
and sinon in repo data.